### PR TITLE
fix remove error

### DIFF
--- a/server.js
+++ b/server.js
@@ -114,7 +114,7 @@ fastify.get('/peer/create/:username', function(request, reply) {
     }
 })
 
-fastify.get('/client/remove/:username', function(request, reply) {
+fastify.get('/peer/remove/:username', function(request, reply) {
     cliMsg(`${request.ip} requested removal of peer ${request.params.username}`)
     if (!authAction(request)) return
     exec(`bash ./scripts/bash/wg.sh -d ${request.params.username}`, (err, stdout, stderr) => {


### PR DESCRIPTION
I changed '/client/remove/:username' to '/peer/remove/:username' so it matches both the documentation and the other client management actions