### PR TITLE
workaround to append user info to tmp file

### DIFF
--- a/scripts/bash/wg.sh
+++ b/scripts/bash/wg.sh
@@ -89,6 +89,10 @@ add_user() {
         echo "wg set failed"
         rm -rf $user
         exit 1
+    else
+    cat >> $SAVED_FILE <<EOF
+$user $ip $public_key
+EOF
     fi
 
     echo -e "\e[44m[wg-api cli]\e[0m Created $user"


### PR DESCRIPTION
**workaround to append user info to tmp file**

- fixes #6
- fixes #10

see my comments on #6 :

> The same here. The problem is, `generate_and_install_server_config_file()` loops `$SAVED_FILE` content to generate `$WG_TMP_CONF_FILE`. But `add_user()` doesn't add newly added user to `$SAVED_FILE`. Thus, the `$SAVED_FILE` remains empty. As a result, this makes final `/etc/wireguard/$_INTERFACE.conf` file corrupted. This issue is the same with issue #10.
> 
> As a workaround, I've added a line in the `add_user()` to append the newly added user details to `$SAVED_FILE`. I will send this as a PR. But it should be a more powerful solution to generate `/etc/wireguard/$_INTERFACE.conf` from profiles instead of appending user info to the temp file.

